### PR TITLE
Feature/posts index

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -17,7 +17,18 @@ class PostsController < ApplicationController
   end
 
   def index
-    @posts = Post.all.order(created_at: :desc)
+    @posts = Post.includes(:user, :vegetable)
+
+    case params[:filter]
+    when 'failure'
+      @posts = @posts.where(category: 'つまずきノート')
+    when 'mine'
+      @posts = @posts.where(user_id: current_user.id) if user_signed_in?
+    else
+      @posts = @posts.where(category: '育成記録')
+    end
+
+    @posts = @posts.order(created_at: :desc)
   end
 
   private

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -25,7 +25,7 @@ class PostsController < ApplicationController
     when 'mine'
       @posts = @posts.where(user_id: current_user.id) if user_signed_in?
     else
-      @posts = @posts.where(category: '育成記録')
+      @posts = @posts.where(category: 'grow_log')
     end
 
     @posts = @posts.order(created_at: :desc)

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -10,6 +10,9 @@
 </div>
 
 <!-- 🗂 投稿一覧表示 -->
+<% if @posts.empty? %>
+  <p>投稿がまだありません。</p>
+<% else %>
 <% @posts.each do |post| %>
   <div class="post-card">
     <% if post.image.attached? %>
@@ -21,8 +24,8 @@
     <p><strong>作成日:</strong> <%= post.created_at.strftime("%Y年%m月%d日") %></p>
     <%= link_to '詳細を見る', post_path(post) %>
   </div>
+ <% end %>
 <% end %>
-
 
 
 

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -12,7 +12,9 @@
 <!-- 🗂 投稿一覧表示 -->
 <% @posts.each do |post| %>
   <div class="post-card">
-    <%= image_tag post.image.variant(resize_to_limit: [200, 200]) if post.image.attached? %>
+    <% if post.image.attached? %>
+      <%= image_tag url_for(post.image), width: 200, height: 200 %>
+    <% end %>
     <p><strong>タイトル:</strong> <%= post.title %></p>
     <p><strong>ユーザー名:</strong> <%= post.user.nickname %></p>
     <p><strong>カテゴリー:</strong> <%= category_label(post.category) %></p>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,11 +1,35 @@
 <h1>投稿一覧</h1>
 
+<!-- 🔁 カテゴリー切り替えタブ -->
+<div class="filter-tabs">
+  <%= link_to "育成記録", posts_path(filter: "record"), class: ("active" if params[:filter].nil? || params[:filter] == "record") %> |
+  <%= link_to "つまずきノート", posts_path(filter: "failure"), class: ("active" if params[:filter] == "failure") %> |
+  <% if user_signed_in? %>
+    <%= link_to "自分の投稿", posts_path(filter: "mine"), class: ("active" if params[:filter] == "mine") %>
+  <% end %>
+</div>
+
+<!-- 🗂 投稿一覧表示 -->
 <% @posts.each do |post| %>
-  <div>
-    <h2><%= post.title %></h2>
-    <p><%= post.content %></p>
-    <p>カテゴリー: <%= category_label(post.category) %></p>
-    <p>野菜: <%= post.vegetable.name if post.vegetable %></p>
-    <hr>
+  <div class="post-card">
+    <%= image_tag post.image.variant(resize_to_limit: [200, 200]) if post.image.attached? %>
+    <p><strong>タイトル:</strong> <%= post.title %></p>
+    <p><strong>ユーザー名:</strong> <%= post.user.nickname %></p>
+    <p><strong>カテゴリー:</strong> <%= category_label(post.category) %></p>
+    <p><strong>作成日:</strong> <%= post.created_at.strftime("%Y年%m月%d日") %></p>
+    <%= link_to '詳細を見る', post_path(post) %>
   </div>
 <% end %>
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -5,7 +5,7 @@
   <%= link_to "育成記録", posts_path(filter: "record"), class: ("active" if params[:filter].nil? || params[:filter] == "record") %> |
   <%= link_to "つまずきノート", posts_path(filter: "failure"), class: ("active" if params[:filter] == "failure") %> |
   <% if user_signed_in? %>
-    <%= link_to "自分の投稿", posts_path(filter: "mine"), class: ("active" if params[:filter] == "mine") %>
+    <%= link_to "マイページ", posts_path(filter: "mine"), class: ("active" if params[:filter] == "mine") %>
   <% end %>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
-  root 'home#index'
+  root 'posts#index'
   devise_for :users
   resources :posts
-  resources :posts, only: [:new, :create]
+  resources :posts, only: [:index, :new, :create, :show]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
# What
投稿一覧ページの表示機能を実装

# Why
-ユーザーが投稿された内容を一覧で閲覧できるようにするため。
-育成記録・つまずきノート・マイページ（自分の投稿）といったカテゴリーで切り替えができるようにすることで、目的に応じた情報を見つけやすくするため。